### PR TITLE
Downgrade package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/node": "22.7.9",
-    "aws-cdk": "2.1012.0",
-    "ts-node": "^10.9.2",
-    "typescript": "~5.6.3",
-    "vitest": "^3.1.2"
+    "@types/node": "18.0.0",
+    "aws-cdk": "2.50.0",
+    "ts-node": "^10.0.0",
+    "typescript": "~4.5.0",
+    "vitest": "^0.20.0"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.190.0",
+    "aws-cdk-lib": "2.50.0",
     "constructs": "^10.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Significantly downgraded all package versions in package.json
- This PR intentionally downgrades dependencies to older versions

## Changes
- @types/node: 22.7.9 → 18.0.0
- aws-cdk: 2.1012.0 → 2.50.0  
- typescript: ~5.6.3 → ~4.5.0
- vitest: ^3.1.2 → ^0.20.0
- aws-cdk-lib: 2.190.0 → 2.50.0
- ts-node: ^10.9.2 → ^10.0.0

## Test plan
- [ ] Verify package installation works with downgraded versions
- [ ] Check that CDK commands still function
- [ ] Ensure TypeScript compilation succeeds
- [ ] Run test suite to confirm compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)